### PR TITLE
Add `useRefs` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog][kac], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+- Added `useRefs`
+
 ## [0.4.3] - 2024-01-31
 
 ### Added

--- a/src/Runtime.lua
+++ b/src/Runtime.lua
@@ -308,7 +308,9 @@ end
 
 	Returns the `ref` table that is attached to the current `useInstance` call.
 
-	This hook can only be used inside `useInstance` and will error if done otherwise.
+	This hook can only be used inside `useInstance` and will error if done otherwise. You can use this instead
+	of the `ref` parameter if you're using nested functions that returns instances and don't want
+	to pass the table to a descendant via prop drilling.
 ]=]
 function Runtime.useRefs(): RefTable
 	local node = stack[#stack].node

--- a/src/Runtime.lua
+++ b/src/Runtime.lua
@@ -31,7 +31,7 @@ type StackFrame = {
 	discriminator: string | number,
 }
 
-type RefTable = { [string]: Instance }
+export type RefTable = { [string]: Instance }
 
 local stack: { StackFrame } = {}
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -13,6 +13,7 @@ return {
 	widget = Runtime.widget,
 	useState = Runtime.useState,
 	useInstance = Runtime.useInstance,
+	useRefs = Runtime.useRefs,
 	useEffect = Runtime.useEffect,
 	useKey = Runtime.useKey,
 	setEventCallback = Runtime.setEventCallback,

--- a/tests/plasma.spec.lua
+++ b/tests/plasma.spec.lua
@@ -63,7 +63,7 @@ return function()
 						BackgroundColor3 = Color3.fromHex("#0f0"),
 						-- children
 						DescendantComponent(),
-					})
+					}),
 				})
 			end
 

--- a/tests/plasma.spec.lua
+++ b/tests/plasma.spec.lua
@@ -5,7 +5,6 @@ return function()
 	describe("plasma", function()
 		it("should create and destroy things", function()
 			local folder = Instance.new("Folder")
-
 			local root = Plasma.new(folder)
 
 			Plasma.start(root, function()
@@ -21,7 +20,6 @@ return function()
 
 		it("should create and destroy from a single start point", function()
 			local folder = Instance.new("Folder")
-
 			local root = Plasma.new(folder)
 
 			local function start(visible)
@@ -38,6 +36,81 @@ return function()
 			start(false)
 
 			expect(folder:FindFirstChildWhichIsA("TextButton")).to.never.be.ok()
+		end)
+
+		it("should support `useRefs` hook", function()
+			local folder = Instance.new("Folder")
+			local root = Plasma.new(folder)
+
+			local refsTable
+
+			local function DescendantComponent()
+				return Plasma.create("Frame", {
+					[Plasma.useRefs()] = "baz",
+					BackgroundColor3 = Color3.fromHex("#00f"),
+				})
+			end
+
+			local function AncestorComponent()
+				local ref = Plasma.useRefs()
+				refsTable = ref
+
+				return Plasma.create("Frame", {
+					[ref] = "foo",
+					BackgroundColor3 = Color3.fromHex("#f00"),
+
+					Plasma.create("Frame", {
+						BackgroundColor3 = Color3.fromHex("#0f0"),
+
+						DescendantComponent(),
+					})
+				})
+			end
+
+			local frame = Plasma.beginFrame(root, function(tbl)
+				expect(Plasma.useInstance(AncestorComponent)).to.equal(tbl)
+			end, refsTable)
+
+			Plasma.continueFrame(frame, function(refs, red, blue)
+				expect(refs.foo).to.be.ok()
+				expect(refs.bar).to.never.be.ok()
+				expect(refs.baz).to.be.ok()
+
+				expect(refs.foo.BackgroundColor3).to.equal(red)
+				expect(refs.baz.BackgroundColor3).to.equal(blue)
+			end, refsTable, Color3.fromHex("#f00"), Color3.fromHex("#00f"))
+
+			Plasma.finishFrame(root)
+		end)
+
+		it("should disallow `useRefs` outside `useInstance`", function()
+			local folder = Instance.new("Folder")
+			local root = Plasma.new(folder)
+
+			Plasma.start(root, function()
+				Plasma.useInstance(function()
+					return Plasma.create("Folder")
+				end)
+
+				expect(Plasma.useRefs).to.throw()
+			end)
+		end)
+
+		it("should disallow mutating the returned refs table", function()
+			local folder = Instance.new("Folder")
+			local root = Plasma.new(folder)
+
+			local refs
+
+			Plasma.start(root, function()
+				refs = Plasma.useInstance(function(ref)
+					return Plasma.create("Folder", { [ref] = "test" })
+				end)
+			end)
+
+			expect(function()
+				refs.test = true
+			end).to.throw()
 		end)
 	end)
 end

--- a/tests/plasma.spec.lua
+++ b/tests/plasma.spec.lua
@@ -58,10 +58,10 @@ return function()
 				return Plasma.create("Frame", {
 					[ref] = "foo",
 					BackgroundColor3 = Color3.fromHex("#f00"),
-
+					-- children
 					Plasma.create("Frame", {
 						BackgroundColor3 = Color3.fromHex("#0f0"),
-
+						-- children
 						DescendantComponent(),
 					})
 				})


### PR DESCRIPTION
## Proposed changes

As your game UI grows, it becomes really difficult to track the instances you want to filter the references - If I had a tree of functions that returns instances, and want to capture one of its descendants, I'd have to pass my `ref` table all the way down the tree just so I could set the reference to be that one instance.

The proposed new hook called `useRefs`, eliminates this issue by grabbing the `ref` table in the current `useInstance` call. This can only be used inside `useInstance` and will error if done otherwise.

## Additional comments

- Adds the missing parameter type for `useInstance`'s callback.
- Freezes the `ref` table after `useCallback` is done executing as it shouldn't be mutated anyways. (New hook's behavior also depends on this)