### PR TITLE
Disable AutoLocalize

### DIFF
--- a/src/create.lua
+++ b/src/create.lua
@@ -53,6 +53,22 @@ local Runtime = require(script.Parent.Runtime)
 	print(ref.button.Text) --> hi
 	```
 ]=]
+
+local GUI_BASE_2D = {
+	"CanvasGroup",
+	"Frame",
+	"ImageLabel",
+	"ScrollingFrame",
+	"TextLabel",
+	"TextButton",
+	"ViewportFrame",
+	"TextBox",
+	"VideoFrame",
+	"ScreenGui",
+	"BillboardGui",
+	"SurfaceGui",
+}
+
 local function create(className, props)
 	props = props or {}
 
@@ -78,6 +94,10 @@ local function create(className, props)
 		else
 			instance[key] = value
 		end
+	end
+
+	if table.find(GUI_BASE_2D, className) then
+		instance.AutoLocalize = false
 	end
 
 	return instance

--- a/src/create.lua
+++ b/src/create.lua
@@ -76,6 +76,10 @@ local function create(className, props)
 
 	local instance = Instance.new(className)
 
+	if props["AutoLocalize"] == nil and table.find(GUI_BASE_2D, className) then
+		props["AutoLocalize"] = false
+	end
+
 	for key, value in pairs(props) do
 		if type(value) == "function" then
 			if eventCallback then
@@ -94,10 +98,6 @@ local function create(className, props)
 		else
 			instance[key] = value
 		end
-	end
-
-	if table.find(GUI_BASE_2D, className) then
-		instance.AutoLocalize = false
 	end
 
 	return instance

--- a/src/widgets/row.lua
+++ b/src/widgets/row.lua
@@ -28,6 +28,7 @@ return Runtime.widget(function(options, fn)
 	local refs = Runtime.useInstance(function(ref)
 		local Frame = Instance.new("Frame")
 		Frame.BackgroundTransparency = 1
+		Frame.AutoLocalize = false
 
 		local UIListLayout = Instance.new("UIListLayout")
 		UIListLayout.SortOrder = Enum.SortOrder.LayoutOrder

--- a/src/widgets/spinner.lua
+++ b/src/widgets/spinner.lua
@@ -16,6 +16,7 @@ return Runtime.widget(function()
 		local Frame = Instance.new("Frame")
 		Frame.BackgroundTransparency = 1
 		Frame.Size = UDim2.new(0, 100, 0, 100)
+		Frame.AutoLocalize = false
 
 		local ImageLabel = Instance.new("ImageLabel")
 		ImageLabel.AnchorPoint = Vector2.new(0.5, 0.5)
@@ -23,6 +24,7 @@ return Runtime.widget(function()
 		ImageLabel.Image = "rbxassetid://2689141406"
 		ImageLabel.Position = UDim2.new(0.5, 0, 0.5, 0)
 		ImageLabel.Size = UDim2.new(0, 100, 0, 100)
+		ImageLabel.AutoLocalize = false
 		ImageLabel.Parent = Frame
 
 		ref.frame = Frame


### PR DESCRIPTION
`AutoLocalize` being on causes Roblox to do work to translate the text. As Plasma is usually used as a debug UI, this is undesirable default behavior and can sometimes cause performance issues.

We just disabled it on the `create` function by checking if the className desired is inherited from `GuiBase2D`, which is the class that implements the property. We also disabled it on some `direct Instance.new` calls.

Matter will need a similar PR, since we use `Instance.new` over there too.